### PR TITLE
Add handling for cr lf line endings

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -24,7 +24,7 @@ class Parser {
     let rest = '';
     for await (const chunk of this.chuncks()) {
       const text = rest + decoder.decode(chunk);
-      const lines = text.split('\n');
+      const lines = text.split(/\r?\n/);
       rest = lines.pop();
 
       for (const line of lines) yield line;


### PR DESCRIPTION
According to the spec
https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream all 3 types of line endings are supported, but the code splits by lf at the moment.

In theory to handle all three it should be `/\r\n|\r|\n/` let me know if you'd prefer that.